### PR TITLE
Tweak readme.adoc re: misa.B=0

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,6 +1,6 @@
 = RISC-V B
 
-It has been recognized that there is need to officially standardize a "B" extension - that represents the collection of the Zba, Zbb, and Zbs extensions - for the sake of consistency and conciseness across toolchains and how they identify support for these bitmanip extensions (which, for example, are mandated in RVA and RVB profiles). In conjunction with this an official definition of the misa.B bit will be established - along the lines of misa.B=1 indicating support for at least these three extensions (and misa.B=0 indicating that one or more are not supported).
+It has been recognized that there is need to officially standardize a "B" extension - that represents the collection of the Zba, Zbb, and Zbs extensions - for the sake of consistency and conciseness across toolchains and how they identify support for these bitmanip extensions (which, for example, are mandated in RVA and RVB profiles). In conjunction with this an official definition of the misa.B bit will be established - along the lines of misa.B=1 indicating support for at least these three extensions (and misa.B=0 indicating that one or more may not be supported).
 
 == License
 


### PR DESCRIPTION
Since Zba, Zbb, and Zbs predate misa.B,
it's not possible to arrange that misa.B=0 logically implies anything: Existing implementations with Zba, Zbb, and Zbs won't magically sprout a misa.B bit.

The spec apparently gets this correct, but the readme did not.